### PR TITLE
Allow specifying a different file for core

### DIFF
--- a/src/main/java/org/jenkinsci/deprecatedusage/JenkinsFile.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/JenkinsFile.java
@@ -36,7 +36,7 @@ public class JenkinsFile {
     private final String version;
     private final URL url;
     private final String wiki;
-    private final File file;
+    private File file;
     private final File versionsRootDirectory;
     private Future<?> downloadFuture;
 
@@ -66,6 +66,10 @@ public class JenkinsFile {
 
     public File getFile() {
         return file;
+    }
+
+    public void setFile(File file) {
+        this.file = file;
     }
 
     public void startDownloadIfNotExists() {

--- a/src/main/java/org/jenkinsci/deprecatedusage/UpdateCenter.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/UpdateCenter.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.deprecatedusage;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -29,7 +30,7 @@ public class UpdateCenter {
 
         final JSONObject jsonRoot = new JSONObject(string);
         final JSONObject jsonCore = jsonRoot.getJSONObject("core");
-        core = parse(jsonCore);
+        core = parseCore(jsonCore);
 
         final JSONObject jsonPlugins = jsonRoot.getJSONObject("plugins");
         for (final Object pluginId : jsonPlugins.keySet()) {
@@ -51,6 +52,12 @@ public class UpdateCenter {
         final String string = new String(updateCenterData, StandardCharsets.UTF_8)
                 .replace("updateCenter.post(", "");
         return string;
+    }
+
+    private JenkinsFile parseCore(JSONObject jsonObject) throws MalformedURLException, JSONException {
+        JenkinsFile core = parse(jsonObject);
+        core.setFile(new File(System.getProperty("coreFileOverride", core.getFile().toString())));
+        return core;
     }
 
     private JenkinsFile parse(JSONObject jsonObject) throws MalformedURLException, JSONException {


### PR DESCRIPTION
This allows specifying a different file path for Jenkins war.

While one could just replace the war file, there are two problems:

* The version number changes over time, and one needs to keep track of the exact file path to override. And with the next update-center.json update, the previously used custom build will be deleted unexpectedly.
* Declaring a different release to be e.g. "core 2.50" gets confusing quickly. Is it the cached real release, or a custom build?

So better to just allow pointing to a different file. Note that it will be created if it doesn't exist, but won't be deleted (unless inside `work/core/`)

CC @evernat 