### PR TITLE
Fix broken embeddable status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 **Finds and reports usage of deprecated Jenkins api in plugins** (except api used in jelly and groovy files and in WEB-INF/lib/*.jar)
 
-[![Build Status](https://ci.jenkins-ci.org/buildStatus/icon?job=Reporting/infra_deprecated-usage-in-plugins)](https://ci.jenkins-ci.org/view/All/job/Reporting/job/infra_deprecated-usage-in-plugins/)
+[![Build Status](https://ci.jenkins.io/view/All/job/Reporting/job/deprecated-usage-in-plugins/badge/icon)](https://ci.jenkins.io/view/All/job/Reporting/job/deprecated-usage-in-plugins/)
 
 Current results in summary:
 * 1114 plugins


### PR DESCRIPTION
See https://ci.jenkins.io/view/All/job/Reporting/job/deprecated-usage-in-plugins/badge/

Fixes the currently broken:

![image](https://user-images.githubusercontent.com/223853/51475985-5f1aef00-1d84-11e9-996c-f6cbd1ae92e7.png)

cc @daniel-beck 