### PR TITLE
Add a way to specify additional classes by configuration (instead of hardcoding it and recompiling)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+target/
+work/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+# used JDK11 because on jdk-8 I get SUREFIRE-1588. Debian Docker images are a bit dead to me :(
+FROM maven:3.6.0-jdk-11
+LABEL maintainer="Baptiste Mathus <batmat@batmat.net>"
+
+RUN mkdir /project
+VOLUME /project/work
+ADD . /project
+
+WORKDIR /project
+CMD ["mvn", "--show-version", "clean", "package", "exec:java"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ LABEL maintainer="Baptiste Mathus <batmat@batmat.net>"
 RUN mkdir /project
 VOLUME /project/work
 ADD . /project
-
 WORKDIR /project
-CMD ["mvn", "--show-version", "clean", "package", "exec:java"]
+RUN mvn clean package && \
+    cd target && \
+    mv deprecated-usage-in-plugins-*-SNAPSHOT-jar-with-dependencies.jar deprecated-usage-fat.jar
+
+ENTRYPOINT ["java", "-jar", "target/deprecated-usage-fat.jar"]

--- a/README.md
+++ b/README.md
@@ -1,22 +1,32 @@
-**Finds and reports usage of deprecated Jenkins api in plugins** (except api used in jelly and groovy files and in WEB-INF/lib/*.jar)
+# Tool to scan for API Usage in Jenkins plugins
+
+This tools offers a facility to scan Jenkins plugins for a given API usage.
+It will automatically download all existing Jenkins plugins, and analyze them using the provided criteria.
+ 
+NOTE: it will **NOT** find usages in Jelly and Groovy files, and in WEB-INF/lib/*.jar.
+
 
 [![Build Status](https://ci.jenkins-ci.org/buildStatus/icon?job=Reporting/infra_deprecated-usage-in-plugins)](https://ci.jenkins-ci.org/view/All/job/Reporting/job/infra_deprecated-usage-in-plugins/)
 
-Current results in summary:
-* 1114 plugins
-* 560 plugins using a deprecated Jenkins api
-* 20 deprecated classes, 170 deprecated methods and 12 deprecated fields are used in plugins
-* 28 deprecated and public Jenkins classes, 319 deprecated methods, 58 deprecated fields are not used in the latest published plugins
-
 See details and deprecated usage for each plugin in the [continuous integration](https://ci.jenkins-ci.org/view/All/job/Reporting/job/infra_deprecated-usage-in-plugins/lastSuccessfulBuild/artifact/target/output.html) or in this [example of output](../../blob/master/Output_example.html).
 
-See also:
+## See also:
 * [Jenkins policy for API deprecation](https://issues.jenkins-ci.org/browse/JENKINS-31035)
 * The old [Plugin compat tester](https://github.com/jenkinsci/plugin-compat-tester) and its [disabled job](https://ci.jenkins-ci.org/job/plugin-compat-tester/)
 
-To run the tool yourself : Checkout and run with "mvn clean compile exec:java".
-Note: it is quite long to download all the plugins the first time (1.8 GB).
+## Usage
+
+To run the tool yourself, see [USAGE](USAGE.adoc)
+
+### Historical note
+
+This tool was originally designed to look exclusively for @Deprecated code usages.
+In early 2019, this has been extended to allow looking for any class usage.
+
+## References
+
+Creator: Emeric Vernat
+
+## LICENSE
 
 [License MIT](../../blob/master/LICENSE.txt)
-
-Author Emeric Vernat

--- a/USAGE.adoc
+++ b/USAGE.adoc
@@ -20,6 +20,33 @@ docker run -ti \
            -v maven-repo:/root/.m2/repository \
            -v downloaded-plugins:/project/work \
            -v $PWD/output:/project/output \
-           -v $PWD/additional-classes.txt:/project/additional-classes.txt:ro \
               jenkins/usage-in-plugins
+...
+
+# Run it on a subset of classes (with all sample output)
+$ cat add.txt
+javax/xml/bind/DatatypeConverterImpl
+javax/xml/bind/DatatypeConverter
+$ docker run -ti \
+           -v maven-repo:/root/.m2/repository \
+           -v downloaded-plugins:/project/work \
+           -v $PWD/output:/project/output \
+           -v $PWD/add.txt:/project/additional-classes.txt:ro \
+              jenkins/usage-in-plugins --additionalClasses additional-classes.txt --onlyAdditionalClasses
+Downloaded update-center.json
+All files are up to date (1590 plugins)
+Analyzing deprecated api in Jenkins
+additional-classes.txt found, adding 2 classes
+        adding javax/xml/bind/DatatypeConverterImpl
+        adding javax/xml/bind/DatatypeConverter
+Analyzing deprecated usage in plugins
+.......... .......... .......... .......... ..........
+.......... .......... .......... .......... ..........
+.......... .......... .......... .......... ..........
+.........Writing output/usage-by-plugin.json
+Writing output/usage-by-plugin.html
+Writing output/deprecated-and-unused.json
+Writing output/deprecated-and-unused.html
+Writing output/usage-by-api.json
+Writing output/usage-by-api.html
 ----

--- a/USAGE.adoc
+++ b/USAGE.adoc
@@ -14,5 +14,12 @@ Simply do:
 [source]
 ----
 docker build -t jenkins/usage-in-plugins .
-docker run  -ti -v maven-repo:/root/.m2/repository -v downloaded-plugins:/project/work -v $PWD/output:/project/output -v $PWD/additional-classes.txt:/project/additional-classes.txt:ro jenkins/usage-in-plugins
+
+# Run it
+docker run -ti \
+           -v maven-repo:/root/.m2/repository \
+           -v downloaded-plugins:/project/work \
+           -v $PWD/output:/project/output \
+           -v $PWD/additional-classes.txt:/project/additional-classes.txt:ro \
+              jenkins/usage-in-plugins
 ----

--- a/USAGE.adoc
+++ b/USAGE.adoc
@@ -1,0 +1,18 @@
+= How to use this tool
+
+== Direct usage
+
+[source]
+mvn clean compile exec:java
+
+== Dockerfile
+
+A Dockerfile is provided for ease of running without necessary environment (JDK, Maven, etc.)
+
+Simply do:
+
+[source]
+----
+docker build -t jenkins/usage-in-plugins .
+docker run -v maven-repo:/root/.m2/repository -v downloaded-plugins:/project/work jenkins/usage-in-plugins
+----

--- a/USAGE.adoc
+++ b/USAGE.adoc
@@ -14,5 +14,5 @@ Simply do:
 [source]
 ----
 docker build -t jenkins/usage-in-plugins .
-docker run -v maven-repo:/root/.m2/repository -v downloaded-plugins:/project/work jenkins/usage-in-plugins
+docker run  -ti -v maven-repo:/root/.m2/repository -v downloaded-plugins:/project/work -v $PWD/output:/project/output -v $PWD/additional-classes.txt:/project/additional-classes.txt:ro jenkins/usage-in-plugins
 ----

--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.3</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,11 @@
 			<version>2.5</version>
 		</dependency>
 		<dependency>
+			<groupId>args4j</groupId>
+			<artifactId>args4j</artifactId>
+			<version>2.33</version>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.12</version>

--- a/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedApi.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedApi.java
@@ -46,6 +46,9 @@ public class DeprecatedApi {
     }
 
     public void analyze(File coreFile) throws IOException {
+        if(Options.get().onlyAdditionalClasses) {
+            return;
+        }
         final WarReader warReader = new WarReader(coreFile, false);
         try {
             String fileName = warReader.nextClass();

--- a/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedApi.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedApi.java
@@ -1,18 +1,19 @@
 package org.jenkinsci.deprecatedusage;
 
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
-
-import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.FieldVisitor;
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
 
 public class DeprecatedApi {
     // some plugins such as job-dsl has following code without using deprecated :
@@ -32,6 +33,7 @@ public class DeprecatedApi {
     private final Set<String> methods = new LinkedHashSet<>();
     private final Set<String> fields = new LinkedHashSet<>();
     private final ClassVisitor classVisitor = new CalledClassVisitor();
+
 
     public static String getMethodKey(String className, String name, String desc) {
         return className + SEPARATOR + name + desc;
@@ -73,6 +75,10 @@ public class DeprecatedApi {
 
     public Set<String> getFields() {
         return fields;
+    }
+
+    public void addClasses(List<String> additionalClasses) {
+        classes.addAll(additionalClasses);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsage.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsage.java
@@ -62,19 +62,6 @@ public class DeprecatedUsage {
         } finally {
             warReader.close();
         }
-
-        // final InputStream input = new FileInputStream(pluginFile);
-        // final JarReader jarReader = new JarReader(input);
-        // try {
-        // String fileName = jarReader.nextClass();
-        // while (fileName != null) {
-        // analyze(jarReader.getInputStream(), aClassVisitor);
-        // fileName = jarReader.nextClass();
-        // }
-        // } finally {
-        // jarReader.close();
-        // input.close();
-        // }
     }
 
     private void analyze(InputStream input, ClassVisitor aClassVisitor) throws IOException {

--- a/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsage.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsage.java
@@ -88,13 +88,8 @@ public class DeprecatedUsage {
     }
 
     void methodCalled(String className, String name, String desc) {
-        // Calls to java and javax are ignored first
-        if (!isJavaClass(className)) {
-            if (className.endsWith("DefaultTypeTransformation")) {
-                // various DefaultTypeTransformation#box signatures seem false positive in plugins written in Groovy
-                return;
-            }
-            if (!className.contains("jenkins") && !className.contains("hudson") && !className.contains("org/kohsuke")) {
+
+            if (!shouldAnalyze(className)) {
                 return;
             }
             if (deprecatedApi.getClasses().contains(className)) {
@@ -112,7 +107,45 @@ public class DeprecatedUsage {
                     }
                 }
             }
+    }
+
+    /**
+     * Returns true if given class should be analyzed
+     *
+     * @see Options
+     */
+    private boolean shouldAnalyze(String className)  {
+
+        if (className.endsWith("DefaultTypeTransformation")) {
+            // various DefaultTypeTransformation#box signatures seem false positive in plugins written in Groovy
+            return false;
         }
+
+        // if an additionalClasses file is specified, and this matches, we ignore Options' includeJavaCoreClasses or onlyIncludeJenkinsClasses
+        // values, given the least surprise is most likely that if the user explicitly passed a file, s/he does want it to be analyzed
+        // even if coming from java.*, javax.*, or not from Jenkins core classes itself
+        if (Options.get().additionalClassesFile != null) {
+            final boolean b = Options.getAdditionalClasses().stream()
+                    .anyMatch(className::startsWith);
+            if(b) {
+                return true;
+            }
+        }
+
+        if(Options.get().onlyAdditionalClasses) {
+            return false;
+        }
+
+        // Calls to java and javax are ignored by default if not explicitly requested
+        if(className.startsWith("java/") || className.startsWith("javax")) {
+            return Options.get().includeJavaCoreClasses;
+        }
+
+        if(!className.contains("jenkins") && !className.contains("hudson") && !className.contains("org/kohsuke")) {
+            return Options.get().onlyIncludeJenkinsClasses;
+        }
+
+        return true;
     }
 
     void fieldCalled(String className, String name, String desc) {

--- a/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsage.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsage.java
@@ -134,7 +134,7 @@ public class DeprecatedUsage {
         }
 
         // Calls to java and javax are ignored by default if not explicitly requested
-        if(className.startsWith("java/") || className.startsWith("javax")) {
+        if(isJavaClass(className)) {
             return Options.get().includeJavaCoreClasses;
         }
 

--- a/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsage.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/DeprecatedUsage.java
@@ -124,12 +124,9 @@ public class DeprecatedUsage {
         // if an additionalClasses file is specified, and this matches, we ignore Options' includeJavaCoreClasses or onlyIncludeJenkinsClasses
         // values, given the least surprise is most likely that if the user explicitly passed a file, s/he does want it to be analyzed
         // even if coming from java.*, javax.*, or not from Jenkins core classes itself
-        if (Options.get().additionalClassesFile != null) {
-            final boolean b = Options.getAdditionalClasses().stream()
-                    .anyMatch(className::startsWith);
-            if(b) {
-                return true;
-            }
+        if (Options.get().additionalClassesFile != null &&
+                Options.getAdditionalClasses().stream().anyMatch(className::startsWith)) {
+            return true;
         }
 
         if(Options.get().onlyAdditionalClasses) {

--- a/src/main/java/org/jenkinsci/deprecatedusage/Main.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Main.java
@@ -1,9 +1,12 @@
 package org.jenkinsci.deprecatedusage;
 
+import org.apache.commons.io.FileUtils;
+
 import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -31,6 +34,7 @@ public class Main {
         System.out.println("Analyzing deprecated api in Jenkins");
         final File coreFile = updateCenter.getCore().getFile();
         final DeprecatedApi deprecatedApi = new DeprecatedApi();
+        addClassesToAnalyze(deprecatedApi);
         deprecatedApi.analyze(coreFile);
 
         System.out.println("Analyzing deprecated usage in plugins");
@@ -49,6 +53,22 @@ public class Main {
 
         System.out.println("duration : " + (System.currentTimeMillis() - start) + " ms at "
                 + DateFormat.getDateTimeInstance().format(new Date()));
+    }
+
+    /**
+     * Adds hardcoded classes to analyze for usage. This is mostly designed for finding classes planned for deprecation,
+     * but can be also used to find any class usage.
+     *
+     */
+    private static void addClassesToAnalyze(DeprecatedApi deprecatedApi) throws IOException {
+        File additionalClassesFile = new File("additional-classes.txt");
+        if (additionalClassesFile.exists()) {
+            System.out.println(additionalClassesFile+" found, adding classes");
+            List<String> additionalClasses = FileUtils.readLines(additionalClassesFile, StandardCharsets.UTF_8.name());
+            deprecatedApi.addClasses(additionalClasses);
+        } else {
+            System.out.println("No "+additionalClassesFile+" file, only already deprecated class will be searched for");
+        }
     }
 
     private static List<DeprecatedUsage> analyzeDeprecatedUsage(List<JenkinsFile> plugins,

--- a/src/main/java/org/jenkinsci/deprecatedusage/Main.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Main.java
@@ -27,17 +27,18 @@ public class Main {
     public static void main(String[] args) throws Exception {
         new Main().doMain(args);
     }
+
     public void doMain(String[] args) throws Exception {
 
         final CmdLineParser commandLineParser = new CmdLineParser(Options.get());
         try {
             commandLineParser.parseArgument(args);
-        }catch (CmdLineException e) {
+        } catch (CmdLineException e) {
             commandLineParser.printUsage(System.err);
             System.exit(1);
         }
 
-        if(Options.get().help) {
+        if (Options.get().help) {
             commandLineParser.printUsage(System.err);
             System.exit(0);
         }

--- a/src/main/java/org/jenkinsci/deprecatedusage/Main.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Main.java
@@ -21,7 +21,7 @@ import java.util.zip.ZipException;
 
 public class Main {
     private static final String UPDATE_CENTER_URL =
-    // "http://updates.jenkins-ci.org/experimental/update-center.json";
+    // "http://updates.jenkins-ci.org/experimental/update-center.json"; // TODO: introduce new option to choose UC, see Options class
     "http://updates.jenkins-ci.org/update-center.json";
 
     public static void main(String[] args) throws Exception {

--- a/src/main/java/org/jenkinsci/deprecatedusage/Main.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Main.java
@@ -1,12 +1,12 @@
 package org.jenkinsci.deprecatedusage;
 
-import org.apache.commons.io.FileUtils;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
 
 import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -25,6 +25,22 @@ public class Main {
     "http://updates.jenkins-ci.org/update-center.json";
 
     public static void main(String[] args) throws Exception {
+        new Main().doMain(args);
+    }
+    public void doMain(String[] args) throws Exception {
+
+        final CmdLineParser commandLineParser = new CmdLineParser(Options.get());
+        try {
+            commandLineParser.parseArgument(args);
+        }catch (CmdLineException e) {
+            commandLineParser.printUsage(System.err);
+            System.exit(1);
+        }
+
+        if(Options.get().help) {
+            commandLineParser.printUsage(System.err);
+            System.exit(0);
+        }
         final long start = System.currentTimeMillis();
         final UpdateCenter updateCenter = new UpdateCenter(new URL(UPDATE_CENTER_URL));
         System.out.println("Downloaded update-center.json");
@@ -61,13 +77,11 @@ public class Main {
      *
      */
     private static void addClassesToAnalyze(DeprecatedApi deprecatedApi) throws IOException {
-        File additionalClassesFile = new File("additional-classes.txt");
-        if (additionalClassesFile.exists()) {
-            System.out.println(additionalClassesFile+" found, adding classes");
-            List<String> additionalClasses = FileUtils.readLines(additionalClassesFile, StandardCharsets.UTF_8.name());
+        if (Options.get().additionalClassesFile != null) {
+            List<String> additionalClasses = Options.getAdditionalClasses();
             deprecatedApi.addClasses(additionalClasses);
         } else {
-            System.out.println("No "+additionalClassesFile+" file, only already deprecated class will be searched for");
+            System.out.println("No 'additionalClassesFile' option, only already deprecated class will be searched for");
         }
     }
 

--- a/src/main/java/org/jenkinsci/deprecatedusage/Options.java
+++ b/src/main/java/org/jenkinsci/deprecatedusage/Options.java
@@ -1,0 +1,71 @@
+package org.jenkinsci.deprecatedusage;
+
+import org.apache.commons.io.FileUtils;
+import org.kohsuke.args4j.Option;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * Command line options for usages scan.
+ * Not thread safe.
+ */
+public class Options {
+
+    private static final Options OPTIONS = new Options();
+    private static List<String> additionalClasses;
+
+    @Option(name = "-h", aliases = "--help", usage = "Shows help")
+    public boolean help;
+
+    @Option(name = "-c", aliases = "--includeJavaCoreClasses", usage = "Include classes from java.* and javax.* in the report (not included by default)")
+    public boolean includeJavaCoreClasses;
+
+    @Option(name = "--additionalClasses", metaVar = "FILENAME", usage = "File name for additional classes to scan")
+    public File additionalClassesFile;
+
+    @Option(name = "--onlyAdditionalClasses", depends = "--additionalClasses", usage = "Only include in the report the specified classes")
+    public boolean onlyAdditionalClasses;
+
+    @Option(name = "--onlyIncludeJenkinsClasses", usage = "Only include in the report Jenkins related classes (jenkins.*, hudson.*, etc.")
+    public boolean onlyIncludeJenkinsClasses;
+
+    private Options() {
+    }
+
+    /**
+     * Singleton
+     */
+    public static final Options get() {
+        return OPTIONS;
+    }
+
+    /**
+     * Returns the additional classes if the related {@link #additionalClassesFile} has been specified.
+     *
+     * @throws IOException if called when {@link #additionalClassesFile} has not been specified.
+     */
+    static List<String> getAdditionalClasses() throws IllegalArgumentException {
+        if (additionalClasses != null) {
+            return additionalClasses;
+        }
+        File additionalClassesFile = get().additionalClassesFile;
+        if (!additionalClassesFile.exists()) {
+            throw new IllegalArgumentException(
+                    "Additional classes file option provided, but file cannot be found (" + additionalClassesFile + ")");
+        }
+
+        try {
+            additionalClasses = FileUtils.readLines(additionalClassesFile, StandardCharsets.UTF_8.name());
+            System.out.println(additionalClassesFile + " found, adding " + additionalClasses.size() + " classes");
+            for (String additionalClass : additionalClasses) {
+                System.out.println("\tadding " + additionalClass);
+            }
+            return additionalClasses;
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}


### PR DESCRIPTION
(PR filed in the context of [JENKINS-55704](https://issues.jenkins-ci.org/browse/JENKINS-55704))

This PR introduces args4j in the codebase to allow using the tool without having to recompile it each time.

The core goal here was to scan JAXB classes, and we decided to make this reusable instead of just hardcoding our need, given we may need soon to do this again for JAXB or other APIs.

* [x] Add options to run the tool without code modification/hardcoding :heavy_check_mark: 

The new way of using the tool will look like the following (renders as https://gistpreview.github.io/?8016715184ded96b93f631b11c64f972/demo-usage-by-plugin-only-additionalClasses.html):

```shell
# Build it if needed
$ mvn clean package
# Run it (help mode to show existing options)
$ java -jar target/deprecated-usage-in-plugins-0.1-SNAPSHOT-jar-with-dependencies.jar --help
 --additionalClasses FILENAME  : File name for additional classes to scan
 --onlyAdditionalClasses       : Only include in the report the specified
                                 classes (default: false)
 --onlyIncludeJenkinsClasses   : Only include in the report Jenkins related
                                 classes (jenkins.*, hudson.*, etc. (default:
                                 false)
 -c (--includeJavaCoreClasses) : Include classes from java.* and javax.* in the
                                 report (not included by default) (default:
                                 false)
 -h (--help)                   : Shows help (default: true)

$ cat add.txt
javax/xml/bind/DatatypeConverterImpl
javax/xml/bind/DatatypeConverter
$ java -jar target/deprecated-usage-in-plugins-0.1-SNAPSHOT-jar-with-dependencies.jar --additionalClasses add.txt --onlyAdditionalClasses
Downloaded update-center.json
All files are up to date (1590 plugins)
Analyzing deprecated api in Jenkins
add.txt found, adding 2 classes
        adding javax/xml/bind/DatatypeConverterImpl
        adding javax/xml/bind/DatatypeConverter
Analyzing deprecated usage in plugins
.......... .......... .......... .......... ..........
.......... .......... .......... .......... ..........
.......... .......... .......... .......... ..........
.........Writing output/usage-by-plugin.json
Writing output/usage-by-plugin.html
Writing output/deprecated-and-unused.json
Writing output/deprecated-and-unused.html
Writing output/usage-by-api.json
Writing output/usage-by-api.html
duration : 7150 ms at 8 févr. 2019 12:17:45
```

@jenkins-infra/java11-support and @daniel-beck who's used this tool regularly.