### PR TITLE
Only build the default branch periodically

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,8 @@ pipeline {
       label 'maven'
    }
 
-   triggers {
-      cron('H H * * *')
+   if (env.BRANCH_IS_PRIMARY) {
+      properties([pipelineTriggers([cron('H H * * *')])])
    }
 
    options {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,8 @@ pipeline {
 
    if (env.BRANCH_IS_PRIMARY) {
       properties([pipelineTriggers([cron('H H * * *')])])
+   else {
+      properties([pipelineTriggers([cron('')])])
    }
 
    options {


### PR DESCRIPTION
Instead of building all branches and PRs periodically, the change proposed alters the cron schedule to build the default branch only, what we need to aggregate the results.